### PR TITLE
github actions: Execute tests in release mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,17 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --release --verbose


### PR DESCRIPTION
Split the 'Run Tests' step into a parallel job and build with the `--release` flag. Performance on intensive operations is not good in the default debug builds, so the extra time building with optimizations enabled pays off in faster test execution.

Currently it takes around 12 minutes to get ci feedback on changes.