### PR TITLE
end2end-example: Update to criterion 0.5

### DIFF
--- a/end2end-example/client/Cargo.toml
+++ b/end2end-example/client/Cargo.toml
@@ -20,7 +20,7 @@ ark-std = { version = "0.4.0", default-features = false }
 bytes = { version = "1.1" }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports", "async", "async_tokio"] }
+criterion = { version = "0.5", features = ["html_reports", "async", "async_tokio"] }
 
 [[bench]]
 name = "client_benchmark"


### PR DESCRIPTION
Update to the current release of the benchmark framework to address `cargo audit` warnings about the unmaintained `atty` crate.

NB this benchmark panics when I try to run it.