### PR TITLE
Remove unused rust-crypto dependency

### DIFF
--- a/boomerang/Cargo.toml
+++ b/boomerang/Cargo.toml
@@ -17,5 +17,4 @@ merlin = { version = "3.0.0"}
 num-bigint = { version = "0.4", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 digest = { version = "0.9.0", default-features = false }
-rust-crypto = "^0.2"
 rewards-proof = { path="../rewards-proof" }


### PR DESCRIPTION
This is no longer referenced by the code. Addresses a `cargo audit` warning about the crate being unmaintained.