### PR TITLE
Fix warnings in the end2end client benchmark code

### DIFF
--- a/end2end-example/client/benches/client_benchmark.rs
+++ b/end2end-example/client/benches/client_benchmark.rs
@@ -56,7 +56,7 @@ async fn issuance_protocol(ckp: UKeyPair<Config>, skp: ServerKeyPair<Config>) ->
     let check = SigVerify::<Config>::verify(
         skp.s_key_pair.verifying_key,
         skp.s_key_pair.tag_key,
-        &sig,
+        sig,
         "message",
     );
     assert!(check);
@@ -111,7 +111,7 @@ async fn collection_protocol(
     let check = SigVerify::<Config>::verify(
         skp.s_key_pair.verifying_key,
         skp.s_key_pair.tag_key,
-        &sig_n,
+        sig_n,
         "message",
     );
     assert!(check);
@@ -171,7 +171,7 @@ async fn spending_protocol(
     let check = SigVerify::<Config>::verify(
         skp.s_key_pair.verifying_key,
         skp.s_key_pair.tag_key,
-        &sig_n,
+        sig_n,
         "message",
     );
     assert!(check);


### PR DESCRIPTION
- Remove unused types.
- Constrain the benchmark sample size with a `BenchmarkGroup` derived from the passed framework handle rather than creating a separate one.
- Remove redundant `&` references.