### PR TITLE
bulletproofs: Address test-code warnings

### DIFF
--- a/bulletproofs/Cargo.toml
+++ b/bulletproofs/Cargo.toml
@@ -86,32 +86,3 @@ harness = false
 name = "r1cs_secq256k1"
 harness = false
 required-features = ["yoloproofs"]
-
-[profile.release]
-opt-level = 3
-lto = "thin"
-incremental = true
-panic = 'abort'
-
-[profile.bench]
-opt-level = 3
-debug = false
-rpath = false
-lto = "thin"
-incremental = true
-debug-assertions = false
-
-[profile.dev]
-opt-level = 3
-lto = "thin"
-incremental = true
-debug-assertions = true
-debug = true
-panic = 'abort'
-
-[profile.test]
-opt-level = 3
-lto = "thin"
-incremental = true
-debug-assertions = true
-debug = true

--- a/bulletproofs/src/util.rs
+++ b/bulletproofs/src/util.rs
@@ -220,9 +220,10 @@ fn sum_of_powers_slow<G: AffineRepr>(x: &G::ScalarField, n: usize) -> G::ScalarF
     exp_iter::<G>(*x).take(n).sum()
 }
 
-/// Raises `x` to the power `n` using binary exponentiation,
-/// with (1 to 2)*lg(n) scalar multiplications.
-/// TODO: a consttime version of this would be awfully similar to a Montgomery ladder.
+/// Raises `x` to the power `n` using binary exponentiation
+///
+/// Uses (1 to 2)*lg(n) scalar multiplications.
+/// TODO: a consttime version of this would be similar to a Montgomery ladder.
 pub fn scalar_exp_vartime<G: AffineRepr>(x: &G::ScalarField, mut n: u64) -> G::ScalarField {
     let mut result = G::ScalarField::one();
     let mut aux = *x; // x, x^2, x^4, x^8, ...
@@ -238,6 +239,7 @@ pub fn scalar_exp_vartime<G: AffineRepr>(x: &G::ScalarField, mut n: u64) -> G::S
 }
 
 /// Raises `x` to the power `n`.
+///
 /// Naive implementation for verifying correctness.
 #[cfg(test)]
 fn scalar_exp_vartime_slow<G: AffineRepr>(x: &G::ScalarField, n: u64) -> G::ScalarField {

--- a/bulletproofs/src/util.rs
+++ b/bulletproofs/src/util.rs
@@ -257,11 +257,12 @@ fn scalar_exp_vartime_slow<G: AffineRepr>(x: &G::ScalarField, n: u64) -> G::Scal
 ///
 /// Panics if the slices are of different length.
 fn add_vec<G: AffineRepr>(a: &[G::ScalarField], b: &[G::ScalarField]) -> Vec<G::ScalarField> {
-    assert_eq!(a.len(), b.len(),
-        "argument length must match for vector addition");
-    a.iter().zip(b)
-        .map(|(a, b)| *a + *b)
-        .collect()
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "argument length must match for vector addition"
+    );
+    a.iter().zip(b).map(|(a, b)| *a + *b).collect()
 }
 
 #[cfg(test)]

--- a/bulletproofs/src/util.rs
+++ b/bulletproofs/src/util.rs
@@ -238,6 +238,8 @@ pub fn scalar_exp_vartime<G: AffineRepr>(x: &G::ScalarField, mut n: u64) -> G::S
 }
 
 /// Raises `x` to the power `n`.
+/// Naive implementation for verifying correctness.
+#[cfg(test)]
 fn scalar_exp_vartime_slow<G: AffineRepr>(x: &G::ScalarField, n: u64) -> G::ScalarField {
     let mut result = G::ScalarField::one();
     for _ in 0..n {
@@ -304,5 +306,19 @@ mod tests {
         assert_eq!(flat_slice(&v), &[0u8; 64][..]);
         assert_eq!(v[0], F::zero());
         assert_eq!(v[1], F::zero());
+    }
+
+    #[test]
+    /// Confirm different implementations give identical results
+    fn scalar_exp_variants() {
+        type G = ark_secq256k1::Affine;
+        type F = ark_secq256k1::Fr;
+        // This can be made deterministic by setting
+        // DETERMINISTIC_TEST_RNG=1 in the environment
+        let a = F::from(42u64);
+        let n = 12;
+        let v = scalar_exp_vartime::<G>(&a, n);
+
+        assert_eq!(v, scalar_exp_vartime_slow::<G>(&a, n));
     }
 }

--- a/bulletproofs/tests/r1cs_curve25519.rs
+++ b/bulletproofs/tests/r1cs_curve25519.rs
@@ -229,6 +229,7 @@ fn example_gadget<CS: ConstraintSystem<Fr>>(
 }
 
 // Prover's scope
+#[allow(clippy::too_many_arguments)]
 fn example_gadget_proof(
     pc_gens: &PedersenGens<EdwardsAffine>,
     bp_gens: &BulletproofGens<EdwardsAffine>,

--- a/bulletproofs/tests/r1cs_secq256k1.rs
+++ b/bulletproofs/tests/r1cs_secq256k1.rs
@@ -229,7 +229,7 @@ fn example_gadget<CS: ConstraintSystem<Fr>>(
 }
 
 // Prover's scope
-#[allow(too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn example_gadget_proof(
     pc_gens: &PedersenGens<Affine>,
     bp_gens: &BulletproofGens<Affine>,

--- a/bulletproofs/tests/r1cs_secq256k1.rs
+++ b/bulletproofs/tests/r1cs_secq256k1.rs
@@ -229,6 +229,7 @@ fn example_gadget<CS: ConstraintSystem<Fr>>(
 }
 
 // Prover's scope
+#[allow(too_many_arguments)]
 fn example_gadget_proof(
     pc_gens: &PedersenGens<Affine>,
     bp_gens: &BulletproofGens<Affine>,

--- a/macros/src/bench_tacl.rs
+++ b/macros/src/bench_tacl.rs
@@ -247,24 +247,12 @@ macro_rules! bench_tacl_make_all {
     ($config: ty, $curve_name: tt) => {
         $crate::bench_tacl_import_everything!();
         $crate::bench_tacl_commit_time!($config, acl_commit, $curve_name);
-        $crate::bench_tacl_challenge_time!(
-            $config,
-            acl_challenge,
-            $curve_name
-        );
+        $crate::bench_tacl_challenge_time!($config, acl_challenge, $curve_name);
         $crate::bench_tacl_respond_time!($config, acl_respond, $curve_name);
         $crate::bench_tacl_sign_time!($config, acl_sign, $curve_name);
         $crate::bench_tacl_verify_time!($config, acl_verify, $curve_name);
-        $crate::bench_tacl_sign_proof_time!(
-            $config,
-            acl_sign_proof,
-            $curve_name
-        );
-        $crate::bench_tacl_sign_verify_time!(
-            $config,
-            acl_sign_verify,
-            $curve_name
-        );
+        $crate::bench_tacl_sign_proof_time!($config, acl_sign_proof, $curve_name);
+        $crate::bench_tacl_sign_verify_time!($config, acl_sign_verify, $curve_name);
 
         criterion_group!(
             benches,

--- a/macros/src/bench_tboomerang.rs
+++ b/macros/src/bench_tboomerang.rs
@@ -600,91 +600,23 @@ macro_rules! bench_tboomerang_import_everything {
 macro_rules! bench_tboomerang_make_all {
     ($config: ty, $curve_name: tt) => {
         $crate::bench_tboomerang_import_everything!();
-        $crate::bench_tboomerang_issuance_m1_time!(
-            $config,
-            boomerang_issuance_m1,
-            $curve_name
-        );
-        $crate::bench_tboomerang_issuance_m2_time!(
-            $config,
-            boomerang_issuance_m2,
-            $curve_name
-        );
-        $crate::bench_tboomerang_issuance_m3_time!(
-            $config,
-            boomerang_issuance_m3,
-            $curve_name
-        );
-        $crate::bench_tboomerang_issuance_m4_time!(
-            $config,
-            boomerang_issuance_m4,
-            $curve_name
-        );
-        $crate::bench_tboomerang_issuance_m5_time!(
-            $config,
-            boomerang_issuance_m5,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m1_time!(
-            $config,
-            boomerang_collection_m1,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m2_time!(
-            $config,
-            boomerang_collection_m2,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m3_time!(
-            $config,
-            boomerang_collection_m3,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m4_time!(
-            $config,
-            boomerang_collection_m4,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m5_time!(
-            $config,
-            boomerang_collection_m5,
-            $curve_name
-        );
-        $crate::bench_tboomerang_collection_m6_time!(
-            $config,
-            boomerang_collection_m6,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m1_time!(
-            $config,
-            boomerang_spending_m1,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m2_time!(
-            $config,
-            boomerang_spending_m2,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m3_time!(
-            $config,
-            boomerang_spending_m3,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m4_time!(
-            $config,
-            boomerang_spending_m4,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m5_time!(
-            $config,
-            boomerang_spending_m5,
-            $curve_name
-        );
-        $crate::bench_tboomerang_spending_m6_time!(
-            $config,
-            boomerang_spending_m6,
-            $curve_name
-        );
+        $crate::bench_tboomerang_issuance_m1_time!($config, boomerang_issuance_m1, $curve_name);
+        $crate::bench_tboomerang_issuance_m2_time!($config, boomerang_issuance_m2, $curve_name);
+        $crate::bench_tboomerang_issuance_m3_time!($config, boomerang_issuance_m3, $curve_name);
+        $crate::bench_tboomerang_issuance_m4_time!($config, boomerang_issuance_m4, $curve_name);
+        $crate::bench_tboomerang_issuance_m5_time!($config, boomerang_issuance_m5, $curve_name);
+        $crate::bench_tboomerang_collection_m1_time!($config, boomerang_collection_m1, $curve_name);
+        $crate::bench_tboomerang_collection_m2_time!($config, boomerang_collection_m2, $curve_name);
+        $crate::bench_tboomerang_collection_m3_time!($config, boomerang_collection_m3, $curve_name);
+        $crate::bench_tboomerang_collection_m4_time!($config, boomerang_collection_m4, $curve_name);
+        $crate::bench_tboomerang_collection_m5_time!($config, boomerang_collection_m5, $curve_name);
+        $crate::bench_tboomerang_collection_m6_time!($config, boomerang_collection_m6, $curve_name);
+        $crate::bench_tboomerang_spending_m1_time!($config, boomerang_spending_m1, $curve_name);
+        $crate::bench_tboomerang_spending_m2_time!($config, boomerang_spending_m2, $curve_name);
+        $crate::bench_tboomerang_spending_m3_time!($config, boomerang_spending_m3, $curve_name);
+        $crate::bench_tboomerang_spending_m4_time!($config, boomerang_spending_m4, $curve_name);
+        $crate::bench_tboomerang_spending_m5_time!($config, boomerang_spending_m5, $curve_name);
+        $crate::bench_tboomerang_spending_m6_time!($config, boomerang_spending_m6, $curve_name);
 
         criterion_group!(
             benches,

--- a/rewards-proof/src/api.rs
+++ b/rewards-proof/src/api.rs
@@ -10,7 +10,6 @@ use std::vec;
 #[derive(Debug)]
 pub enum RewardsProofError {
     /// This error occurs when the commitments cannot be deserialized.
-    #[cfg_attr(feature = "std", error("Commitments cannot be deserialized."))]
     CommitmentsDeserializationError,
 }
 


### PR DESCRIPTION
Address various issues with the bulletproofs code

- Rewrite `utils::add_vec` to use iterators
- Add some minimal tests for utils
- Fix dead code warnings with annotations
- Remove inactive `profile` and `cfg_attr` directives