### PR TITLE
Attribute projects our implementation is based on

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,27 @@
+name: Makefile
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run make
+      run: make
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run make test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ clean:
 
 test:
 	cargo test --release
+	cargo run --release --example example_proofs
 	@echo "Starting end2end example server and client..."
 	# Build the server explicitly so it doesn't race the client
 	cargo build --release --bin server

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,29 @@
+all: build
+
+.PHONY: all help build check test bench clean
+
+help:
+	@echo "usage: make {build|test|clean|bench}"
+
 build:
 	cargo build
 
-all: build
+check: test
 
-help:
-	@echo "usage: make $(prog) [debug=1]"
-
-run:
-	cargo build
-	cargo run
+clean:
+	cargo clean
 
 test:
-	cargo build
-	cargo test
+	cargo test --release
+	@echo "Starting end2end example server and client..."
+	# Build the server explicitly so it doesn't race the client
+	cargo build --release --bin server
+	# Run the server in the background, terminate it after the client
+	cargo run --release --bin server & \
+		export SERVER_PID=$$!; \
+		cargo run --release --bin client; \
+		kill -s HUP $$SERVER_PID
+	@echo "Ok"
 
 bench:
-	cargo build
 	cargo bench

--- a/README.md
+++ b/README.md
@@ -2,26 +2,29 @@
 
 In order to build, run either:
 
-```
-  make build
-  make run
-```
+    make
 
 or
 
-```
-  cargo build
-  cargo run
-```
+    cargo build
 
 To test:
 
-```
-  make test
-```
+    cargo test --release
 
 To benchmark:
 
+    cargo bench
+
+To see the the protocol in action, run the end2end example client and server
+programs in separate terminals:
+```sh
+cargo run --bin server
 ```
-  make bench
+and then
+```sh
+cargo run --bin client
 ```
+
+These end2end examples are also run automatically after the unit tests
+as part of `make test`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Boomerang
 
+Boomerang uses cryptographic black-box accumulators to implement a
+privacy-preserving, distributed, participation incentive system.
+Using this protocol, clients can efficiently prove participation
+in a set of online events without revealing specific information
+about when and with whom.
+
+## Quick Start
+
 In order to build, run either:
 
     make
@@ -28,3 +36,17 @@ cargo run --bin client
 
 These end2end examples are also run automatically after the unit tests
 as part of `make test`.
+
+## Components
+
+The implementation is broken down into a number of crates handling
+specific parts of the protocol, tests, and demonstration code.
+
+- `boomerang` Overall protocol implementation with separate representations for the client and server sides.
+- `pedersen` Commitment scheme after **Pedersen,** “[Non-Interactive and Information-Theoretic Secure Verifiable Secret Sharing](https://doi.org/10.1007/3-540-46766-1_9).” *Advances in Cryptology* CRYPTO ’91, LNCS 576, pp. 129-140, 1992. Based on [code](https://github.com/brave-experiments/CDLS) from the [CDLS paper](https://eprint.iacr.org/2023/1595).
+- `t256` and `t384` Elliptic curve implementations using the [arkworks](https://arkworks.rs) framework. These are also from CDLS.
+- `acl` [Anonymous Credentials Light](https://eprint.iacr.org/2012/298) blind signature system after **Baldimtsi and Lysyanskaya**, 2012.
+- `bulletproofs` Zero-knowledge proof scheme from [Short proofs for Confidential Transactions](https://eprint.iacr.org/2017/1066.pdf), 2017. This implementation is derived from the one by [dalek cryptography](https://github.com/dalek-cryptography/bulletproofs) with some borrowing from the [curve tree](https://github.com/simonkamp/curve-trees/tree/main/bulletproofs) fork and [Alex Ozdemir's](https://github.com/alex-ozdemir/bulletproofs) arkworks version. Used under the MIT license.
+- `rewards-proof` Credit redemption for participation incentive schemes. Also based on bulletproofs.
+- `macros` Various utilities for generating test boilerplate. Also from CDLS.
+- `end2end_example` Demonstrates using the protocol between a simple http server and clients.


### PR DESCRIPTION
Add a "Components" section to the README describing each crate in the workspace, along with links to relevant papers or code the implementation is based on.

While here, prune the build instruction to look a little less intimidating and clean up the Makefile so all targets succeed and we run more of the integration test code under `make test`.