### PR TITLE
Address clippy doc lints

### DIFF
--- a/bulletproofs/src/generators.rs
+++ b/bulletproofs/src/generators.rs
@@ -25,7 +25,7 @@ use sha3::Sha3_512;
 ///
 /// * `B`: the `ristretto255` basepoint;
 /// * `B_blinding`: the result of `ristretto255` SHA3-512
-/// hash-to-group on input `B_bytes`.
+///   hash-to-group on input `B_bytes`.
 #[derive(Copy, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct PedersenGens<G: AffineRepr> {
     /// Base for the committed value

--- a/bulletproofs/src/util.rs
+++ b/bulletproofs/src/util.rs
@@ -112,8 +112,10 @@ impl<G: AffineRepr> VecPoly3<G> {
     }
 
     /// Compute an inner product of `lhs`, `rhs` which have the property that:
+    ///
     /// - `lhs.0` is zero;
     /// - `rhs.2` is zero;
+    ///
     /// This is the case in the constraint system proof.
     pub fn special_inner_product(lhs: &Self, rhs: &Self) -> Poly6<G> {
         // TODO: make checks that l_poly.0 and r_poly.2 are zero.

--- a/end2end-example/client/src/main.rs
+++ b/end2end-example/client/src/main.rs
@@ -570,7 +570,7 @@ async fn main() {
         let check = SigVerify::<Config>::verify(
             skp.s_key_pair.verifying_key,
             skp.s_key_pair.tag_key,
-            &sig,
+            sig,
             "message",
         );
         assert!(check);

--- a/pedersen/src/pedersen_config.rs
+++ b/pedersen/src/pedersen_config.rs
@@ -27,9 +27,11 @@ pub trait PedersenConfig: SWCurveConfig {
     /// |p|/2 bits of security.
     const SECPARAM: usize;
 
-    /// from_oc. This function takes an `x` in OCurve's ScalarField and converts it
+    /// This function takes an `x` in OCurve's ScalarField and converts it
     /// into an element of the ScalarField of the current curve.
+    ///
     /// * `x` - the element ∈ OCurve's ScalarField.
+    ///
     /// Returns `x` as an element of Self::ScalarField.
     fn from_oc(
         x: <Self::OCurve as CurveConfig>::ScalarField,
@@ -38,54 +40,65 @@ pub trait PedersenConfig: SWCurveConfig {
         <Self as CurveConfig>::ScalarField::from(x_bt)
     }
 
-    /// from_ob_to_os. This function takes an `x` in the OCurve's BaseField and converts
+    /// This function takes an `x` in the OCurve's BaseField and converts
     /// it into an element of the Scalar field of the OCurve.
+    ///
     /// * `x` - the element ∈ OCurve's BaseField.
+    ///
     /// Returns `y` ∈ OCurve's ScalarField.
     fn from_ob_to_os(
         x: <Self::OCurve as CurveConfig>::BaseField,
     ) -> <Self::OCurve as CurveConfig>::ScalarField;
 
-    /// from_ob_to_sf. This function takes an `x` in the OCurve's BaseField and converts
+    /// This function takes an `x` in the OCurve's BaseField and converts
     /// it into an element of the ScalarField of the current curve.
+    ///
     /// * `x` - the element ∈ OCurve's BaseField.
+    ///
     /// Returns `x` as an element of Self::ScalarField.
     fn from_ob_to_sf(
         x: <Self::OCurve as CurveConfig>::BaseField,
     ) -> <Self as CurveConfig>::ScalarField;
 
-    /// from_ob_to_sf. This function takes an `x` in the OCurve's ScalarField and converts
+    /// This function takes an `x` in the OCurve's ScalarField and converts
     /// it into an element of the ScalarField of the current curve.
+    ///
     /// * `x` - the element ∈ OCurve's ScalarField.
+    ///
     /// Returns `x` as an element of Self::ScalarField.
     fn from_os_to_sf(
         x: <Self::OCurve as CurveConfig>::ScalarField,
     ) -> <Self as CurveConfig>::ScalarField;
 
-    /// from_bf_to_sf. This function takes an `x` in  Self::BaseField and converts
+    /// This function takes an `x` in  Self::BaseField and converts
     /// it into an element of the ScalarField of the current curve.
+    ///
     /// * `x` - the element ∈ Self::BaseField.
+    ///
     /// Returns `x` as an element of Self::ScalarField.
     fn from_bf_to_sf(x: <Self as CurveConfig>::BaseField) -> <Self as CurveConfig>::ScalarField;
 
     fn from_u64_to_sf(x: u64) -> <Self as CurveConfig>::ScalarField;
 
-    /// make_challenge_from_buffer. This function accepts a challenge slice (ideally produced by a transcript)
+    /// This function accepts a challenge slice (ideally produced by a transcript)
     /// and converts it into an element of Self::ScalarField.
     /// This function exists primarily to circumvent an API issue with Merlin.
-    /// * `chal_buf` - a slice of bytes (representing a serialised curve point), to be used to
-    ///                make a element of the ScalarField.
+    ///
+    /// * `chal_buf` - a slice of bytes (representing a serialised curve point),
+    ///   to be used to make a element of the ScalarField.
+    ///
     /// Returns a scalar field element.
     fn make_challenge_from_buffer(chal_buf: &[u8]) -> <Self as CurveConfig>::ScalarField {
         <Self as CurveConfig>::ScalarField::deserialize_compressed(chal_buf).unwrap()
     }
 
-    /// make_commitment_from_other. This function accepts an element `val` of OCurve::BaseField and
+    /// This function accepts an element `val` of OCurve::BaseField and
     /// forms a commitment C = val * g + r*h, where `g` and `h` are generators of the Self::Curve.
     /// This function uses the supplied rng to produce the random value `r`.
     /// # Arguments
     /// * `val` - the value to which we are committing.
-    /// * `rng` - the random number generator that is being used. This must be a cryptographically secure RNG.
+    /// * `rng` - the random number generator that is being used.
+    ///   This must be a cryptographically secure RNG.
     fn make_commitment_from_other<T: RngCore + CryptoRng>(
         val: <<Self as PedersenConfig>::OCurve as CurveConfig>::BaseField,
         rng: &mut T,
@@ -93,27 +106,30 @@ pub trait PedersenConfig: SWCurveConfig {
         PedersenComm::new(Self::from_ob_to_sf(val), rng)
     }
 
-    /// make_single_bit_challenge. This function accepts a single bit value `v` and returns:
+    /// This function accepts a single bit value `v` and returns:
     /// * -1 (in the ScalarField) if `v == 0`.
     /// *  1 (in the ScalarField) if `v == 1`.
+    ///
     /// For any other value of `v` this function panics.
+    ///
     /// # Arguments
     /// * `v` - the single bit challenge.
     fn make_single_bit_challenge(v: u8) -> <Self as CurveConfig>::ScalarField;
 
-    /// OGENERATOR2. This acts as a second generator for OCurve. The reason why this
+    /// This acts as a second generator for OCurve. The reason why this
     /// exists is to allow Pedersen Commitments over OCurve to be easy to form.
     const OGENERATOR2: sw::Affine<Self::OCurve>;
 
-    /// CP1. This constant is the representation of "1" in the ScalarField of `Self`.
+    /// This constant is the representation of "1" in the ScalarField of `Self`.
     const CP1: Self::ScalarField;
 
-    /// CM1. This constant is the representation of "-1" in the ScalarField of `Self`.
+    /// This constant is the representation of "-1" in the ScalarField of `Self`.
     const CM1: Self::ScalarField;
 
-    /// create_commitments_to_coords. This function accepts a series of affine points (from the underyling OCurve)
+    /// This function accepts a series of affine points (from the underyling OCurve)
     /// and creates commitments to each co-ordinate of each point, returning the results as a tuple.
     /// The formed commitments are commitments over the relevant T Curve.
+    ///
     /// # Arguments
     /// * `a`: one of the summands.
     /// * `b`: the other summand.
@@ -143,11 +159,13 @@ pub trait PedersenConfig: SWCurveConfig {
         )
     }
 
-    /// get_random_p. This function is a helper function for returning a random value from
+    /// This function is a helper function for returning a random value from
     /// the scalar field of the OCurve.
+    ///
     /// # Arguments
-    /// * `rng` - the random number generator used to produce the random value. Must be a cryptographically
-    /// secure RNG.
+    /// * `rng` - the random number generator used to produce the random value.
+    ///   Must be a cryptographically secure RNG.
+    ///
     /// Returns a random scalar value from OCurve::ScalarField.
     fn get_random_p<T: RngCore + CryptoRng>(
         rng: &mut T,
@@ -155,13 +173,15 @@ pub trait PedersenConfig: SWCurveConfig {
         <Self::OCurve as CurveConfig>::ScalarField::rand(rng)
     }
 
-    /// create_commit_other. This function accepts a value (`val` ∈ OCurve::ScalarField)
+    /// This function accepts a value (`val` ∈ OCurve::ScalarField)
     /// and produces a new Pedersen Commitment C = val*g + r*h, where `g`, `h` are public
     /// generators of OCurve and `r` is a random element of OCurve::ScalarField.
+    ///
     /// # Arguments
     /// * `val - the value that is being committed to.
-    /// * `rng` - the random number generator used to produce the random value. Must be a cryptographically
-    /// secure RNG.
+    /// * `rng` - the random number generator used to produce the random value.
+    ///   Must be a cryptographically secure RNG.
+    ///
     /// Returns a new commitment to `val` as a tuple.
     fn create_commit_other<T: RngCore + CryptoRng>(
         val: &<Self::OCurve as CurveConfig>::ScalarField,
@@ -173,13 +193,15 @@ pub trait PedersenConfig: SWCurveConfig {
         Self::create_commit_other_with_both(val, &Self::get_random_p(rng))
     }
 
-    /// create_multi_commit_other. This function accepts a values (`vals` ∈ OCurve::ScalarField)
+    /// This function accepts a values (`vals` ∈ OCurve::ScalarField)
     /// and produces a new Pedersen Commitment C = (vals)*g + r*h, where `g`, `h` are public
     /// generators of OCurve and `r` is a random element of OCurve::ScalarField.
+    ///
     /// # Arguments
     /// * `vals - the values that is being committed to.
-    /// * `rng` - the random number generator used to produce the random value. Must be a cryptographically
-    /// secure RNG.
+    /// * `rng` - the random number generator used to produce the random value.
+    ///   Must be a cryptographically secure RNG.
+    ///
     /// Returns a new commitment to `val` as a tuple.
     fn create_multi_commit_other<T: RngCore + CryptoRng>(
         vals: Vec<&<Self::OCurve as CurveConfig>::ScalarField>,
@@ -191,12 +213,14 @@ pub trait PedersenConfig: SWCurveConfig {
         Self::create_multi_commit_other_with_both(vals, &Self::get_random_p(rng))
     }
 
-    /// create_commit_other_with_both. This function accepts a value (`val` ∈ OCurve::ScalarField)
+    /// This function accepts a value (`val` ∈ OCurve::ScalarField)
     /// and some randomness (`r` ∈ OCurve::ScalarField) and returns a new Pedersen Commitment C =
     /// val*g + r*h, where `g`, `h` are public generators of OCurve.
+    ///
     /// # Arguments
     /// * `val - the value that is being committed to.
     /// * `r` - the randomness value.
+    ///
     /// Returns a new commitment to `val` as a tuple.
     fn create_commit_other_with_both(
         val: &<Self::OCurve as CurveConfig>::ScalarField,
@@ -212,12 +236,14 @@ pub trait PedersenConfig: SWCurveConfig {
         )
     }
 
-    /// create_multi_commit_other_with_both. This function accepts a list of values (`vals` ∈ OCurve::ScalarField)
+    /// This function accepts a list of values (`vals` ∈ OCurve::ScalarField)
     /// and some randomness (`r` ∈ OCurve::ScalarField) and returns a new Pedersen Commitment C =
     /// (vals_i*g) + r*h, where `g`, `h` are public generators of OCurve.
+    ///
     /// # Arguments
     /// * `vals - the values that are being committed to.
     /// * `r` - the randomness value.
+    ///
     /// Returns a new commitment to `vals` as a tuple.
     fn create_multi_commit_other_with_both(
         vals: Vec<&<Self::OCurve as CurveConfig>::ScalarField>,
@@ -401,24 +427,30 @@ impl<P: PedersenConfig> PedersenComm<P> {
         <P as SWCurveConfig>::GENERATOR
     }
 
-    /// new. This function accepts a ScalarField element `x` and an rng, returning a Pedersen Commitment
-    /// to `x`.
+    /// This function creates a new Pedersen Commitment to a scalar value.
+    ///
+    /// This uses the default generators of the `CurveConfig`.
+    ///
     /// # Arguments
     /// * `x` - the value that is committed to.
-    /// * `rng` - the random number generator used to produce the randomness. Must be cryptographically
-    /// secure.
+    /// * `rng` - the random number generator used to produce the randomness.
+    ///   Must be cryptographically secure.
+    ///
     /// Returns a new Pedersen Commitment to `x`.
     pub fn new<T: RngCore + CryptoRng>(x: <P as CurveConfig>::ScalarField, rng: &mut T) -> Self {
         Self::new_with_generators(x, rng, &<P as SWCurveConfig>::GENERATOR, &P::GENERATOR2)
     }
 
-    /// new_multi. This function accepts various ScalarField elements `val` and an rng, returning a Pedersen Commitment
-    /// to `vals`.
+    /// Creates a new Pedersen Commitment to a vector of values.
+    ///
+    /// This uses the default generators of the `CurveConfig`.
+    ///
     /// # Arguments
     /// * `vals` - the values that are committed to.
-    /// * `rng` - the random number generator used to produce the randomness. Must be cryptographically
-    /// secure.
-    /// Returns a new Pedersen Commitment to `x`.
+    /// * `rng` - the random number generator used to produce the randomness.
+    ///   Must be cryptographically secure.
+    ///
+    /// Returns a new Pedersen Commitment to `vals`.
     pub fn new_multi<T: RngCore + CryptoRng>(
         vals: &[<P as CurveConfig>::ScalarField],
         rng: &mut T,
@@ -426,15 +458,19 @@ impl<P: PedersenConfig> PedersenComm<P> {
         Self::new_multi_with_generators(vals, rng, &<P as SWCurveConfig>::GENERATOR, &P::GENERATOR2)
     }
 
-    /// new_with_generator. This function accepts a ScalarField element `x`, an `rng`,
-    /// and two generators (`g`, `q`) and returns a Pedersen Commitment C = xg + rq. Here `r` is
-    /// the produced randomness.
+    /// Creates a new scalar Pedersen Commitment with specific generators.
+    ///
+    /// This function accepts a ScalarField element `x`,
+    /// two generators (`g`, `q`), and returns a Pedersen Commitment
+    /// C = xg + rq, where `r` is a random value.
+    ///
     /// # Arguments
     /// * `x` - the value that is committed to.
-    /// * `rng` - the random number generator used to produce the randomness. Must be cryptographically
-    /// secure.
+    /// * `rng` - the random number generator used to produce the random value.
+    ///   Must be cryptographically secure.
     /// * `g` - a generator of `P`'s scalar field.
     /// * `q` - a distinct generator of `P`'s scalar field.
+    ///
     /// Returns a new commitment to `x`.
     pub fn new_with_generators<T: RngCore + CryptoRng>(
         x: <P as CurveConfig>::ScalarField,
@@ -467,15 +503,20 @@ impl<P: PedersenConfig> PedersenComm<P> {
         }
         panic!()
     }
-    /// new_multi_with_generators. This function accepts a list of ScalarField elements `val`, an `rng`,
-    /// and two generators (`g`, `q`) and returns a Pedersen Commitment C = valsg + rq. Here `r` is
-    /// the produced randomness.
+
+    /// Creates a new vector Pedersen Commitment with specific generators.
+    ///
+    /// This function accepts a slice of ScalarField elements `vals`,
+    /// two generators (`g`, `q`), and returns a Pedersen Commitment
+    /// C = valsg + rq, where `r` is a random value.
+    ///
     /// # Arguments
     /// * `vals` - the values that are committed to.
-    /// * `rng` - the random number generator used to produce the randomness. Must be cryptographically
-    /// secure.
+    /// * `rng` - the random number generator used to produce the randomness.
+    ///   Must be cryptographically secure.
     /// * `g` - a generator of `P`'s scalar field.
     /// * `q` - a distinct generator of `P`'s scalar field.
+    ///
     /// Returns a new commitment to `x`.
     pub fn new_multi_with_generators<T: RngCore + CryptoRng>(
         vals: &[<P as CurveConfig>::ScalarField],
@@ -519,11 +560,13 @@ impl<P: PedersenConfig> PedersenComm<P> {
         )
     }
 
-    /// new_with_both. This function returns a new Pedersen Commitment to `x` with randomness
+    /// This function returns a new Pedersen Commitment to `x` with randomness
     /// `r` (i.e the commitment is C = xg + rq, where `g` and `q` are pre-defined generators.
     /// # Arguments
+    ///
     /// * `x` - the value that is being committed to.
     /// * `r` - the randomness to use.
+    ///
     /// Returns a new commitment to `x`.
     pub fn new_with_both(
         x: <P as CurveConfig>::ScalarField,
@@ -535,11 +578,13 @@ impl<P: PedersenConfig> PedersenComm<P> {
         }
     }
 
-    /// new_multi_with_both. This function returns a new Pedersen Commitment to `vals` with randomness
+    /// This function returns a new Pedersen Commitment to `vals` with randomness
     /// `r` (i.e the commitment is C = valsg + rq, where `g` and `q` are pre-defined generators.
+    ///
     /// # Arguments
     /// * `vals` - the values that are being committed to.
     /// * `r` - the randomness to use.
+    ///
     /// Returns a new commitment to `x`.
     pub fn new_multi_with_both(
         vals: &[<P as CurveConfig>::ScalarField],
@@ -576,13 +621,15 @@ impl<P: PedersenConfig> PedersenComm<P> {
         )
     }
 
-    /// new_multi_with_all_generators. This function accepts a list of ScalarField elements `val`, an `rng`,
+    /// This function accepts a list of ScalarField elements `val`, an `rng`,
     /// and a list of generators, and returns a multi Pedersen Commitment C. Here `r` is
     /// the produced randomness.
+    ///
     /// # Arguments
     /// * `vals` - the values that are committed to.
-    /// * `rng` - the random number generator used to produce the randomness. Must be cryptographically
-    /// secure.
+    /// * `rng` - the random number generator used to produce the randomness.
+    ///   Must be cryptographically secure.
+    ///
     /// Returns a new commitment to `x`.
     pub fn new_multi_with_all_generators<T: RngCore + CryptoRng>(
         vals: &[<P as CurveConfig>::ScalarField],

--- a/pedersen/src/product_protocol.rs
+++ b/pedersen/src/product_protocol.rs
@@ -238,8 +238,8 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// `cx`, `cy` and `cxy`.
     /// # Arguments
     /// * `transcript` - the transcript object that is modified.
-    /// * `rng` - the RNG that is used to produce the random values. Must be
-    /// cryptographically secure.
+    /// * `rng` - the RNG that is used to produce the random values.
+    ///   Must be cryptographically secure.
     /// * `x` - the value that is used to show an opening of `cx`.
     /// * `y` - the value that is used to show an opening of `cy`.
     /// * `cx` - the commitment to x that is opened.
@@ -269,8 +269,8 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// for a new product proof for `x`, `y` against `cx`, `cy` and `cxy`.
     /// # Arguments
     /// * `transcript` - the transcript object that is modified.
-    /// * `rng` - the RNG that is used to produce the random values. Must be
-    /// cryptographically secure.
+    /// * `rng` - the RNG that is used to produce the random values.
+    ///   Must be cryptographically secure.
     /// * `cx` - the commitment to x that is opened.
     /// * `cy` - the commitment to y that is opened.
     /// * `cxy` - the commitment to xy that is opened.
@@ -313,7 +313,7 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// * `x` - the value that is used to show an opening of `cx`.
     /// * `y` - the value that is used to show an opening of `cy`.
     /// * `inter` - the intermediaries. These should have been produced by a
-    /// call to `create_intermediaries`.
+    ///   call to `create_intermediaries`.
     /// * `cx` - the commitment to x that is opened.
     /// * `cy` - the commitment to y that is opened.
     /// * `cxy` - the commitment to xy that is opened.
@@ -423,11 +423,11 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// * `self` - the proof that is being verified.
     /// * `transcript` - the transcript object that's used.
     /// * `cx` - the commitment to x whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cy` - the commitment to y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cxy` - the commitment to x*y whose opening is being proved by this
-    /// function.
+    ///   function.
     pub fn verify(
         &self,
         transcript: &mut Transcript,
@@ -448,11 +448,11 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// * `self` - the proof that is being verified.
     /// * `transcript` - the transcript object that's used.
     /// * `cx` - the commitment to x whose opening is being proved by this
-    /// function.
+    ///    function.
     /// * `cy` - the commitment to y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cxy` - the commitment to x*y whose opening is being proved by this
-    /// function.
+    ///   function.
     pub fn verify_proof_own_challenge(
         &self,
         transcript: &mut Transcript,
@@ -468,11 +468,11 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// # Arguments
     /// * `self` - the proof that is being verified.
     /// * `cx` - the commitment to x whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cy` - the commitment to y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cxy` - the commitment to x*y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `chal_buf` - the buffer that contains the challenge bytes.
     pub fn verify_proof(
         &self,
@@ -492,11 +492,11 @@ impl<P: PedersenConfig> ProductProof<P> {
     /// # Arguments
     /// * `self` - the proof that is being verified.
     /// * `cx` - the commitment to x whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cy` - the commitment to y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `cxy` - the commitment to x*y whose opening is being proved by this
-    /// function.
+    ///   function.
     /// * `chal` - the challenge.
     pub fn verify_with_challenge(
         &self,


### PR DESCRIPTION
Clean up doc comments flagged by new `clippy::doc_lazy_continuation` added in rust 1.80.

Also fix an unnecessary reference in the end2end example client, which I missed on a previous pass.