### PR TITLE
Makefile: remove rewards_proof example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ clean:
 
 test:
 	cargo test --release
-	cargo run --release --example example_proofs
 	@echo "Starting end2end example server and client..."
 	# Build the server explicitly so it doesn't race the client
 	cargo build --release --bin server


### PR DESCRIPTION
This code was removed in addressing #91, but the invocation was left in the makefile, causing `make test` to fail.

It still fails because the end2end example code is out of sync with recent changes, but the rewards_proof removal is expected to be permanent.