### PR TITLE
Acl hvec proof

### DIFF
--- a/acl/src/sign.rs
+++ b/acl/src/sign.rs
@@ -477,7 +477,7 @@ impl<A: ACLConfig> SigProof<A> {
                 let _ = &transcript_v.challenge_bytes(b"challzk3", &mut buf3);
 
                 let ch: <A as CurveConfig>::ScalarField =
-                    <A as CurveConfig>::ScalarField::deserialize_compressed(&buf[..]).unwrap();
+                    <A as CurveConfig>::ScalarField::deserialize_compressed(&buf3[..]).unwrap();
 
                 let a1 = r + sig_m.opening.gamma * ch;
 

--- a/acl/src/sign.rs
+++ b/acl/src/sign.rs
@@ -481,8 +481,8 @@ impl<A: ACLConfig> SigProof<A> {
 
                 let a1 = r + sig_m.opening.gamma * ch;
 
-                let pi = SigProofD { t1, t2, a1 };
-                pi
+                // Opening proof `pi`
+                SigProofD { t1, t2, a1 }
             })
             .collect();
 

--- a/acl/src/sign.rs
+++ b/acl/src/sign.rs
@@ -396,6 +396,8 @@ pub struct SigProof<A: ACLConfig> {
     pub pi1: SigProofD<A>,
     /// p2: the second proof.
     pub pi2: SigProofO<A>,
+    /// p3: the third proof.
+    pub pi3: Vec<SigProofD<A>>,
     /// h_vec: the commitment to the sub values.
     pub h_vec: Vec<sw::Affine<A>>,
     /// val: the first message value.
@@ -457,7 +459,32 @@ impl<A: ACLConfig> SigProof<A> {
 
         let pi1 = SigProofD { t1, t2, a1 };
 
-        // Equality proofs of zeta = h_vec -> TODO
+        // Equality proofs of zeta = h_vec
+        let pi_hvec: Vec<SigProofD<A>> = gens
+            .iter()
+            .take(vals.len())
+            .skip(1)
+            .map(|&item| {
+                let r = <A as CurveConfig>::ScalarField::rand(rng);
+                let t1 = (tag_key.mul(r)).into_affine();
+                let t2 = (item.mul(sig_m.opening.gamma)).into_affine();
+
+                let label3 = b"Chall ACLZK3";
+                let mut transcript_v = Transcript::new(label3);
+                Self::make_transcript(&mut transcript_v, &t1, &t2);
+
+                let mut buf3 = [0u8; 64];
+                let _ = &transcript_v.challenge_bytes(b"challzk3", &mut buf3);
+
+                let ch: <A as CurveConfig>::ScalarField =
+                    <A as CurveConfig>::ScalarField::deserialize_compressed(&buf[..]).unwrap();
+
+                let a1 = r + sig_m.opening.gamma * ch;
+
+                let pi = SigProofD { t1, t2, a1 };
+                pi
+            })
+            .collect();
 
         // Compute partial commitment
         //let mut total: sw::Affine<A> = sw::Affine::identity();
@@ -498,6 +525,7 @@ impl<A: ACLConfig> SigProof<A> {
             b_gamma,
             pi1,
             pi2,
+            pi3: pi_hvec,
             h_vec,
             val,
         }

--- a/acl/src/sign.rs
+++ b/acl/src/sign.rs
@@ -467,7 +467,7 @@ impl<A: ACLConfig> SigProof<A> {
             .map(|&item| {
                 let r = <A as CurveConfig>::ScalarField::rand(rng);
                 let t1 = (tag_key.mul(r)).into_affine();
-                let t2 = (item.mul(sig_m.opening.gamma)).into_affine();
+                let t2 = (item.mul(r)).into_affine();
 
                 let label3 = b"Chall ACLZK3";
                 let mut transcript_v = Transcript::new(label3);

--- a/acl/src/verify.rs
+++ b/acl/src/verify.rs
@@ -278,7 +278,7 @@ impl<A: ACLConfig> SigVerifProof<A> {
             .pi3
             .iter()
             .zip(proof.h_vec.iter())
-            .zip(gens.iter().take(proof.pi3.len()))
+            .zip(gens.iter().take(proof.pi3.len()).skip(1))
         {
             let rhs4 = (tag_key.mul(pi.a1)).into_affine();
             let rhs5 = (gen.mul(pi.a1)).into_affine();

--- a/acl/src/verify.rs
+++ b/acl/src/verify.rs
@@ -267,7 +267,7 @@ impl<A: ACLConfig> SigVerifProof<A> {
         let lhs1 = proof.pi1.t1 + (sig_m.sigma.zeta.mul(ch));
         let lhs2 = proof.pi1.t2 + (proof.b_gamma.mul(ch));
 
-        if (rhs1 == lhs1 && rhs2 == lhs2) == false {
+        if !(rhs1 == lhs1 && rhs2 == lhs2) {
             // Only continue if above proof verifies to true, otherwise we can
             // return early
             return false;
@@ -296,7 +296,7 @@ impl<A: ACLConfig> SigVerifProof<A> {
             let lhs4 = pi.t1 + (sig_m.sigma.zeta.mul(ch3));
             let lhs5 = pi.t2 + (h.mul(ch3));
 
-            if (rhs4 == lhs4 && rhs5 == lhs5) == false {
+            if !(rhs4 == lhs4 && rhs5 == lhs5) {
                 // if any of the proof is false, return immediately
                 return false;
             }
@@ -319,10 +319,7 @@ impl<A: ACLConfig> SigVerifProof<A> {
         let rhs3 = proof.val.mul(ch2) + proof.pi2.t3;
         let lhs3 = (A::GENERATOR2.mul(proof.pi2.a4) + A::GENERATOR.mul(proof.pi2.a3)).into_affine();
 
-        if (rhs3 == lhs3) == false {
-            return false;
-        }
-
-        true
+        // Proof succeeds if these final sides also agree.
+        rhs3 == lhs3
     }
 }

--- a/acl/src/verify.rs
+++ b/acl/src/verify.rs
@@ -244,7 +244,12 @@ impl<A: ACLConfig> SigVerifProof<A> {
         transcript.append_message(b"c1", &compressed_bytes[..]);
     }
 
-    pub fn verify(proof: &SigProof<A>, tag_key: sw::Affine<A>, sig_m: &SigSign<A>) -> bool {
+    pub fn verify(
+        proof: &SigProof<A>,
+        tag_key: sw::Affine<A>,
+        sig_m: &SigSign<A>,
+        gens: &Vec<sw::Affine<A>>,
+    ) -> bool {
         // Equality proof of zeta = b_gamma
         let rhs1 = (tag_key.mul(proof.pi1.a1)).into_affine();
         let rhs2 = (A::GENERATOR.mul(proof.pi1.a1)).into_affine();
@@ -262,9 +267,40 @@ impl<A: ACLConfig> SigVerifProof<A> {
         let lhs1 = proof.pi1.t1 + (sig_m.sigma.zeta.mul(ch));
         let lhs2 = proof.pi1.t2 + (proof.b_gamma.mul(ch));
 
-        let c = rhs1 == lhs1 && rhs2 == lhs2;
+        if (rhs1 == lhs1 && rhs2 == lhs2) == false {
+            // Only continue if above proof verifies to true, otherwise we can
+            // return early
+            return false;
+        }
 
-        // Equality proofs of zeta = h_vec -> TODO
+        // Equality proofs of zeta = h_vec
+        for ((pi, h), gen) in proof
+            .pi3
+            .iter()
+            .zip(proof.h_vec.iter())
+            .zip(gens.iter().take(proof.pi3.len()))
+        {
+            let rhs4 = (tag_key.mul(pi.a1)).into_affine();
+            let rhs5 = (gen.mul(pi.a1)).into_affine();
+
+            let label3 = b"Chall ACLZK3";
+            let mut transcript_v = Transcript::new(label3);
+            Self::make_transcript(&mut transcript_v, &pi.t1, &pi.t2);
+
+            let mut buf3 = [0u8; 64];
+            let _ = &transcript_v.challenge_bytes(b"challzk", &mut buf3);
+
+            let ch3: <A as CurveConfig>::ScalarField =
+                <A as CurveConfig>::ScalarField::deserialize_compressed(&buf3[..]).unwrap();
+
+            let lhs4 = pi.t1 + (sig_m.sigma.zeta.mul(ch3));
+            let lhs5 = pi.t2 + (h.mul(ch3));
+
+            if (rhs4 == lhs4 && rhs5 == lhs5) == false {
+                // if any of the proof is false, return immediately
+                return false;
+            }
+        }
 
         // For our cases, we will always prove knowledge of all signed committed values,
         // but this is not for all cases.
@@ -283,8 +319,10 @@ impl<A: ACLConfig> SigVerifProof<A> {
         let rhs3 = proof.val.mul(ch2) + proof.pi2.t3;
         let lhs3 = (A::GENERATOR2.mul(proof.pi2.a4) + A::GENERATOR.mul(proof.pi2.a3)).into_affine();
 
-        let c2 = rhs3 == lhs3;
+        if (rhs3 == lhs3) == false {
+            return false;
+        }
 
-        c && c2
+        true
     }
 }

--- a/acl/src/verify.rs
+++ b/acl/src/verify.rs
@@ -288,7 +288,7 @@ impl<A: ACLConfig> SigVerifProof<A> {
             Self::make_transcript(&mut transcript_v, &pi.t1, &pi.t2);
 
             let mut buf3 = [0u8; 64];
-            let _ = &transcript_v.challenge_bytes(b"challzk", &mut buf3);
+            let _ = &transcript_v.challenge_bytes(b"challzk3", &mut buf3);
 
             let ch3: <A as CurveConfig>::ScalarField =
                 <A as CurveConfig>::ScalarField::deserialize_compressed(&buf3[..]).unwrap();

--- a/boomerang/src/server.rs
+++ b/boomerang/src/server.rs
@@ -499,7 +499,12 @@ impl<B: BoomerangConfig> SpendVerifyStateS<B> {
             panic!("Boomerang spend-verify: invalid signature");
         }
 
-        let check2 = SigVerifProof::verify(&c_m.s_proof, key_pair.s_key_pair.tag_key, &c_m.sig, &c_m.prev_gens.generators);
+        let check2 = SigVerifProof::verify(
+            &c_m.s_proof,
+            key_pair.s_key_pair.tag_key,
+            &c_m.sig,
+            &c_m.prev_gens.generators,
+        );
         if !check2 {
             panic!("Boomerang spend-verify: invalid proof sig");
         }

--- a/boomerang/src/server.rs
+++ b/boomerang/src/server.rs
@@ -289,7 +289,13 @@ impl<B: BoomerangConfig> CollectionStateS<B> {
             panic!("Boomerang collection: invalid signature");
         }
 
-        let check2 = SigVerifProof::verify(&c_m.s_proof, key_pair.s_key_pair.tag_key, &c_m.sig);
+        let check2 = SigVerifProof::verify(
+            &c_m.s_proof,
+            key_pair.s_key_pair.tag_key,
+            &c_m.sig,
+            &c_m.prev_gens.generators,
+        );
+
         if !check2 {
             panic!("Boomerang collection: invalid proof sig");
         }

--- a/boomerang/src/server.rs
+++ b/boomerang/src/server.rs
@@ -499,7 +499,7 @@ impl<B: BoomerangConfig> SpendVerifyStateS<B> {
             panic!("Boomerang spend-verify: invalid signature");
         }
 
-        let check2 = SigVerifProof::verify(&c_m.s_proof, key_pair.s_key_pair.tag_key, &c_m.sig);
+        let check2 = SigVerifProof::verify(&c_m.s_proof, key_pair.s_key_pair.tag_key, &c_m.sig, &c_m.prev_gens.generators);
         if !check2 {
             panic!("Boomerang spend-verify: invalid proof sig");
         }

--- a/macros/src/bench_tacl.rs
+++ b/macros/src/bench_tacl.rs
@@ -200,7 +200,14 @@ macro_rules! bench_tacl_sign_verify_time {
 
             // Now we can just benchmark how long it takes to create a new multi proof.
             c.bench_function(concat!($curve_name, " acl proof verify time"), |b| {
-                b.iter(|| ACLSPV::verify(&proof, kp.tag_key, &m4));
+                b.iter(|| {
+                    ACLSPV::verify(
+                        &proof,
+                        kp.tag_key,
+                        &m4,
+                        &gens.generators,
+                    )
+                });
             });
         }
     };

--- a/macros/src/bench_tacl.rs
+++ b/macros/src/bench_tacl.rs
@@ -200,14 +200,7 @@ macro_rules! bench_tacl_sign_verify_time {
 
             // Now we can just benchmark how long it takes to create a new multi proof.
             c.bench_function(concat!($curve_name, " acl proof verify time"), |b| {
-                b.iter(|| {
-                    ACLSPV::verify(
-                        &proof,
-                        kp.tag_key,
-                        &m4,
-                        &gens.generators,
-                    )
-                });
+                b.iter(|| ACLSPV::verify(&proof, kp.tag_key, &m4, &gens.generators));
             });
         }
     };

--- a/macros/src/test_acl.rs
+++ b/macros/src/test_acl.rs
@@ -233,6 +233,13 @@ macro_rules! __test_acl {
             assert!(proof.pi1.t1.is_on_curve());
             assert!(proof.pi1.t2.is_on_curve());
             assert!(proof.pi2.t3.is_on_curve());
+            for h in proof.h_vec.iter() {
+                assert!(h.is_on_curve());
+            }
+            for pi in proof.pi3.iter() {
+                assert!(pi.t1.is_on_curve());
+                assert!(pi.t2.is_on_curve());
+            }
         }
 
         #[test]
@@ -279,8 +286,15 @@ macro_rules! __test_acl {
             assert!(proof.pi1.t1.is_on_curve());
             assert!(proof.pi1.t2.is_on_curve());
             assert!(proof.pi2.t3.is_on_curve());
+            for h in proof.h_vec.iter() {
+                assert!(h.is_on_curve());
+            }
+            for pi in proof.pi3.iter() {
+                assert!(pi.t1.is_on_curve());
+                assert!(pi.t2.is_on_curve());
+            }
 
-            let check = ACLSPV::verify(&proof, kp.tag_key, &m4);
+            let check = ACLSPV::verify(&proof, kp.tag_key, &m4, &gens.generators);
             assert!(check == true);
         }
     };


### PR DESCRIPTION
This PR adds DLEQ proofs for the ACL signature proofing equality of zeta = h_vec for all values in the h vector. This proof is coming from https://eprint.iacr.org/2023/707.pdf (Appendix E). It partially fixes issue https://github.com/brave-experiments/Boomerang/issues/64#issuecomment-2236216366. 