### PR TITLE
github-actions: build cargo-audit from source

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,5 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Install
+        run: cargo install --locked cargo-audit@v0.21.1
+
       - name: Audit
         run: cargo audit


### PR DESCRIPTION
The `cargo audit` command no longer seems to be provided as part of the base image. Install it from source instead.

This should get the continuous integration tests running again.

See also [rustsec/audit-check](https://github.com/rustsec/audit-check) for another approach.